### PR TITLE
Fix some typos/missing articles in FRAMEWORK files

### DIFF
--- a/FRAMEWORK.txt
+++ b/FRAMEWORK.txt
@@ -7,42 +7,42 @@
 @brief Toolbox for Nek5000
 
 @details 
-This directory contains number of tools used by toolboxes developed at KTH. 
+This directory contains a number of tools used by toolboxes developed at KTH. 
 Files are grouped by taks and placed in a tree structure, where the parent directories (modules) 
 perform some operations and can define tasks and interfaces that have to be provided by their 
 subdirectories (submodules). This structure can be repeated recursively with submodules becoming
 parent modules for nex level structures. The top level directories are related to the main services 
-that have to be provided for toolboxes. Examplary framework structure is presented in a figure.
+that have to be provided for toolboxes. An examplary framework structure is presented in a figure.
 
 @image html framework.png Examplary framework structure.
 
 Modules can provide tools, [runtime parameters] (@ref parameter_list_page), memory structures (common blocks), 
 define interfaces and perform some tasks.
-The main goal is to simplify development of toolboxes by defining simple tasks that could be used by number of tools. 
-At the same time clear definition of the inteface alows to keep number of different implementation of the same task.
+The main goal is to simplify the development of toolboxes by defining simple tasks that could be used by a number of tools. 
+At the same time, a clear definition of the inteface alows to keep number of different implementation of the same task.
 
 Each module has to contain:
 - FRAMEWORK.txt -module description
 - makefile_usr.inc - compilation rules
 - source code
-- optionally example of \a setup.par including corresponding runtime parameter section
+- optionally, an example of \a setup.par including corresponding runtime parameter section
 
 Dependences between modules are described in FRAMEWORK.txt (present in almost every directory) including:
-- documentation section witten in a form of doxygen C comment
+- documentation section written in a form of doxygen C comment
   + definition of group
-  + description of module purpose
-  + definition of interface provided by module
+  + description of the module's purpose
+  + definition of the interface provided by the module
   + list of required interfaces from submodules (module dependency)
-  + example of module call
+  + example of a module call
   + list of provided runtime parameters
   + list of requred runtime parameters (module dependency)
-  + example of section in \a setup.par file
+  + example of a section in \a setup.par file
 - SUBMODULES - list of existing local submodules (different task implementations)
 - EXCLUSIVE - list of local submodules that cannot be used simultaneously
 - DEFAULT - default submodules
 - CONFLICTS - list of modules in conflict with current module (from other tree branches)
 - REQUIRED - list of required modules (from other tree branches)
-- OBJECT - list of object files for USR variable in makenek
+- OBJECT - list of object files for the USR variable in makenek
 - INCLUDE - list of include files
 
 */

--- a/driver/frame/FRAMEWORK.txt
+++ b/driver/frame/FRAMEWORK.txt
@@ -7,21 +7,21 @@
 @brief Backbone for toolboxes
 
 @details 
-Frame module provides backbone of the whole framework consisting of dynamical 
+The frame module provides backbone of the whole framework consisting of dynamical 
 (as much as fortran 77 allows for it) databases for registered modules, runtime
-parameters and timers. This supposed to simplify interactions between different 
+parameters and timers. This is supposed to simplify interactions between different 
 modules, logging and operations on runtime parameters. It provides interfaces
-for intialisation, monitoring and finalisation of framework. It requires as well
+for intialisation, monitoring and finalisation of the framework. It requires as well
 three subroutines defined in \a setup.usr and providing modules registration 
 (\a frame_usr_register), initialisation (\a frame_usr_init) and finalisation 
 (\a frame_usr_end).
 
-This module provides as well include file FRAMELP defining log priorities and runtime parameter 
-types. Using logging routines from [monitor] (@ref monitor) submodule one can easily specify 
-verbosity of the code. The logging level can be set in two ways: by LOGLEVEL runtime parameter 
+This module also provides an include file FRAMELP defining log priorities and runtime parameter 
+types. Using logging routines from the [monitor] (@ref monitor) submodule, one can easily specify 
+the verbosity of the code. The logging level can be set in two ways: by LOGLEVEL runtime parameter 
 in [_MONITOR] section of \a setup.par file (doeas not cover framework initialisation) 
-or by setting enviromental variable FRAMELOGL. The second way covers all stages of simulation.
-For bash shell this variable can be set by:
+or by setting the enviromental variable FRAMELOGL. The second way covers all stages of the simulation.
+For the bash shell this variable can be set by:
 @code{.sh}
 FRAMELOGL = 5
 export FRAMELOGL

--- a/driver/frame/runparam/FRAMEWORK.txt
+++ b/driver/frame/runparam/FRAMEWORK.txt
@@ -7,7 +7,7 @@
 @brief Routines related to module's runtime parameters.
 
 @details
-This module builds global parameter database for all registered tools.
+This module builds a global parameter database for all registered tools.
 
 @mod_interface
 @interface_list Interface provided:

--- a/io/checkpoint/FRAMEWORK.txt
+++ b/io/checkpoint/FRAMEWORK.txt
@@ -4,9 +4,9 @@
 @defgroup chkpoint  Checkpointing routines
 @ingroup io
 
-@brief Checkopinting routines for toolbox
+@brief Checkpointing routines for toolbox
 
-@details This is the main interface to I/O checkpinting.
+@details This is the main interface to I/O checkpointing.
 
 @mod_interface
 @interface_list Interface provided:

--- a/tools/FRAMEWORK.txt
+++ b/tools/FRAMEWORK.txt
@@ -7,7 +7,7 @@
 @brief Set of tools for Nek5000 framework
 
 @details 
-This directory contains number of tools developed at KTH. 
+This directory contains a number of tools developed at KTH. 
 
 */
 #List of existing submodules

--- a/tools/tstepper/FRAMEWORK.txt
+++ b/tools/tstepper/FRAMEWORK.txt
@@ -7,11 +7,11 @@
 @brief Time stepper for Nek5000
 
 @details
-This module implements time stepper method for linear solver in Nek5000 using userchk interface. 
-It allows to perform number of constant lenght cycles providing the result vector to 
+This module implements time stepper method for linear solver in Nek5000 using the userchk interface. 
+It allows to perform a number of constant length cycles providing the result vector to 
 the submodule. There are two possible submodules: power iteration and spectra calculation
-using Arnoldi algorithm implemented in \a PARPACK. The initial condition for the next stepping
-cycle is provided by submodule. Three stepper modes are supported: direct, adjoint, direct+adjoint.
+using the Arnoldi algorithm implemented in \a PARPACK. The initial condition for the next stepping
+cycle is provided by the submodule. Three stepper modes are supported: direct, adjoint, direct+adjoint.
 
 @mod_interface
 @interface_list Interface provided:

--- a/utility/bcnd/FRAMEWORK.txt
+++ b/utility/bcnd/FRAMEWORK.txt
@@ -4,10 +4,10 @@
 @defgroup bcnd  Boundary condition module
 @ingroup utility
 
-@brief Diverse tools related to applying boundarry conditions
+@brief Diverse tools related to applying boundary conditions
 
 @details
-Set of boundarry condition related routines.
+Set of boundary condition related routines.
 
 */
 #List of existing submodules


### PR DESCRIPTION
I've been going through the files describing the different modules and thought I would fix any typos I find along the way and improve the grammar a bit here and there (mostly articles). This is the result. Not complete by any means, just a small incremental improvement hopefully.