### PR TITLE
Fill pstat swap array up to pstat_svar

### DIFF
--- a/postprocessing/pstat2d/pstat2D.f
+++ b/postprocessing/pstat2d/pstat2D.f
@@ -146,7 +146,7 @@
       do il = 35,38
          pstat_swfield(il) = il-1
       enddo
-      do il = 39,44
+      do il = 39,pstat_svar
          pstat_swfield(il) = il
       enddo
 #ifdef AMR


### PR DESCRIPTION
Needed when custom fields are added to stats, increasing the total number of fields beyond 44.